### PR TITLE
Create subdirectories for namespaced assets

### DIFF
--- a/cartool/main.m
+++ b/cartool/main.m
@@ -163,7 +163,25 @@ void exportCarFileAtPath(NSString * carPath, NSString *outputDirectoryPath)
 	for (NSString *key in [storage allRenditionNames])
 	{
 		printf("%s\n", [key UTF8String]);
-		
+        
+        NSArray* pathComponents = [key pathComponents];
+        if (pathComponents.count > 1)
+        {
+            // Create subdirectories for namespaced assets (those with names like "some/namespace/image-name")
+            NSArray* subdirectoryComponents = [pathComponents subarrayWithRange:NSMakeRange(0, pathComponents.count - 1)];
+            
+            NSString* subdirectoryPath = [outputDirectoryPath copy];
+            for (NSString* pathComponent in subdirectoryComponents)
+            {
+                subdirectoryPath = [subdirectoryPath stringByAppendingPathComponent:pathComponent];
+            }
+            
+            [[NSFileManager defaultManager] createDirectoryAtPath:subdirectoryPath
+                                      withIntermediateDirectories:YES
+                                                       attributes:nil
+                                                            error:&error];
+        }
+        
 		NSMutableArray *images = getImagesArray(catalog, key);
 		for( CUINamedImage *image in images )
 		{


### PR DESCRIPTION
Assets in an Asset Catalog can be namespaced by setting the "Provides Namespace" option on the containing folder. This allows them to be referenced by a path. So if an asset named "orange" is placed in a folder named "apple" that provides a namespace, it can be referenced by "apple/orange".

Currently cartool can't dump these assets unless subdirectories for each namespace are created before running the tool. This change creates them as needed.